### PR TITLE
Update ember-nvd3-shim to ~0.2.0

### DIFF
--- a/blueprints/ember-cli-nvd3/index.js
+++ b/blueprints/ember-cli-nvd3/index.js
@@ -6,6 +6,6 @@ module.exports = {
   normalizeEntityName: function() {},
 
   beforeInstall: function() {
-    return this.addAddonToProject('ember-nvd3-shim@~0.1.4');
+    return this.addAddonToProject('ember-nvd3-shim@~0.2.0');
   }
 };

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",
-    "ember-nvd3-shim": "~0.1.4",
+    "ember-nvd3-shim": "~0.2.0",
     "ember-resolver": "^2.0.3",
     "ember-try": "^0.2.2",
     "loader.js": "^4.0.1"


### PR DESCRIPTION
Fixes #8 by constraining d3.js to `^3`
