### PR TITLE
Check chart existence before trying to remove tooltips.

### DIFF
--- a/addon/components/nvd3-chart.js
+++ b/addon/components/nvd3-chart.js
@@ -26,7 +26,7 @@ export default Ember.Component.extend({
   afterSetup() {},
 
   eventContext: computed(function() {
-    return this.get('targetObject') || this;
+    return this.get('target') || this;
   }),
 
   reDraw: on('didInsertElement', observer('datum', 'datum.[]', function() {

--- a/addon/components/nvd3-chart.js
+++ b/addon/components/nvd3-chart.js
@@ -87,7 +87,7 @@ export default Ember.Component.extend({
     }
 
     // Remove tooltips
-    if(chart.tooltip) {
+    if(chart && chart.tooltip) {
       chart.tooltip.hideDelay(0); // Set the delay to 0 so tooltips will be instantly removed
       chart.tooltip.hidden(true);
     }

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "ember-cli-content-security-policy": "0.4.0",
     "ember-cli-dependency-checker": "^1.2.0",
     "ember-cli-fastboot": "1.0.0-beta.1",
-    "ember-cli-htmlbars": "^1.0.5",
-    "ember-cli-htmlbars-inline-precompile": "^0.3.1",
+    "ember-cli-htmlbars": "^2.0.3",
+    "ember-cli-htmlbars-inline-precompile": "^1.0.2",
     "ember-cli-inject-live-reload": "^1.4.0",
     "ember-cli-jshint": "^1.0.0",
     "ember-cli-qunit": "^2.0.0",
@@ -49,7 +49,7 @@
     "nvd3"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.6"
+    "ember-cli-babel": "^6.8.2"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
Otherwise throws the following error when the component is rendered and then quickly removed.

`Cannot read property 'tooltip' of null`